### PR TITLE
Configure Supabase via environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
 # FluxorHUBAnalisispercepciones
+
+Este proyecto utiliza Supabase como base de datos. Para que la aplicación funcione correctamente es necesario indicar las claves de conexión mediante variables de entorno.
+
+## Variables de entorno requeridas
+
+- `SUPABASE_URL`
+- `SUPABASE_KEY`
+
+Puedes crear un archivo `.env` en la raíz del proyecto con el siguiente contenido:
+
+```bash
+SUPABASE_URL="https://tu-proyecto.supabase.co"
+SUPABASE_KEY="tu-clave-supersecreta"
+```
+
+Algunos entornos de desarrollo cargan estas variables automáticamente. Si no es tu caso, establece las variables antes de iniciar tu servidor o proceso de build:
+
+```bash
+export SUPABASE_URL="https://tu-proyecto.supabase.co"
+export SUPABASE_KEY="tu-clave-supersecreta"
+```
+
+La aplicación intentará utilizar estas variables. Si no existen, se usarán las credenciales por defecto definidas en `js/config.js` y se mostrará una advertencia en la consola.

--- a/js/config.js
+++ b/js/config.js
@@ -1,6 +1,20 @@
-// Conexión a Supabase con tus claves
-const SUPABASE_URL = 'https://eflaynhqmzxchqhkcnzp.supabase.co';
-const SUPABASE_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImVmbGF5bmhxbXp4Y2hxaGtjbnpwIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTM0MDQxODQsImV4cCI6MjA2ODk4MDE4NH0.7t0LNLiv5zNB36SIt7sFhv3GftQ2XqD6L_eKK2rr3NI';
+// Conexión a Supabase. Intenta leer las claves desde variables de entorno
+// (por ejemplo, inyectadas en el build). Si no existen, usa las de respaldo.
+const DEFAULT_SUPABASE_URL = 'https://eflaynhqmzxchqhkcnzp.supabase.co';
+const DEFAULT_SUPABASE_KEY =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImVmbGF5bmhxbXp4Y2hxaGtjbnpwIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTM0MDQxODQsImV4cCI6MjA2ODk4MDE4NH0.7t0LNLiv5zNB36SIt7sFhv3GftQ2XqD6L_eKK2rr3NI';
+
+const env = (typeof process !== 'undefined' && process.env) ? process.env : {};
+
+const SUPABASE_URL = env.SUPABASE_URL || window.SUPABASE_URL || DEFAULT_SUPABASE_URL;
+const SUPABASE_KEY = env.SUPABASE_KEY || window.SUPABASE_KEY || DEFAULT_SUPABASE_KEY;
+
+if (!env.SUPABASE_URL || !env.SUPABASE_KEY) {
+  console.warn(
+    'SUPABASE_URL o SUPABASE_KEY no se encontraron en las variables de entorno. ' +
+    'Se usarán las credenciales predeterminadas definidas en config.js.'
+  );
+}
 
 // Se exporta el cliente para que esté disponible en otros archivos
 export const supabaseClient = supabase.createClient(SUPABASE_URL, SUPABASE_KEY);


### PR DESCRIPTION
## Summary
- read `SUPABASE_URL` and `SUPABASE_KEY` from environment variables
- warn if they aren't provided and fall back to the defaults
- document environment variables in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a97e5cd1c8330bf4e07bb3bd6ee0a