### PR TITLE
Fix message timeout handling

### DIFF
--- a/js/state.js
+++ b/js/state.js
@@ -13,7 +13,6 @@ export const SOURCE_TYPES = {
 };
 
 // --- ESTADO GLOBAL DE LA APLICACIÓN ---
-export let messageTimeout; // Variable para controlar el timer del mensaje
 export const appState = {
     currentReconciliationId: null, // Guarda el ID de la sesión cargada
     providerDiscrepancies: [], // Guarda los desvíos calculados
@@ -26,8 +25,9 @@ export const appState = {
         pending: new Set(),
         reconciled: new Set(),
         unmatched: new Set(),
-        netDifference: 0, 
+        netDifference: 0,
     },
+    messageTimeout: null, // Timer para ocultar mensajes
 };
 
 // --- ELEMENTOS DE LA UI (Interfaz de Usuario) ---

--- a/js/utils.js
+++ b/js/utils.js
@@ -1,11 +1,11 @@
-import { appState, ui, messageTimeout, SOURCE_TYPES } from './state.js';
+import { appState, ui, SOURCE_TYPES } from './state.js';
 import { handleManualSelection } from './providerAnalysis.js';
 
 // --- FUNCIONES AUXILIARES GLOBALES ---
 
 export const showMessage = (message, isError = false) => {
     const msgBox = ui.reconciler.messageBox;
-    clearTimeout(messageTimeout);
+    clearTimeout(appState.messageTimeout);
 
     msgBox.textContent = message;
     msgBox.className = 'message-box';


### PR DESCRIPTION
## Summary
- keep `messageTimeout` in `appState`
- clear the same timeout when displaying messages

## Testing
- `node test_showMessage.js` *(checks message timer reset)*

------
https://chatgpt.com/codex/tasks/task_e_688a97e12a4083309c3865a0bd907b90